### PR TITLE
Init horizontal filtered on load

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/bindfields.js
+++ b/smart_selects/static/smart-selects/admin/js/bindfields.js
@@ -24,6 +24,11 @@
         $.each($(".chained"), function (index, item) {
             initItem(item);
         });
+        $.each($(".filtered"), function (index, item) {
+            if (item.hasAttribute('data-chainfield')) {
+                initItem(item);
+            }
+        });
     });
 
     $(document).ready(function () {


### PR DESCRIPTION
Add missing `initItem` for `.filtered` fields